### PR TITLE
Stop Collecting Logs about Application Insights Logs

### DIFF
--- a/code/infra/function.tf
+++ b/code/infra/function.tf
@@ -102,6 +102,10 @@ resource "azapi_resource" "function" {
             value = "true"
           },
           {
+            name  = "OTEL_PYTHON_REQUESTS_EXCLUDED_URLS"
+            value = ".*.in.applicationinsights.azure.com/.*"
+          },
+          {
             name  = "AZURE_FUNCTIONS_ENVIRONMENT"
             value = "Production"
           },


### PR DESCRIPTION
**Proposed changes**:
- Remove Application Insights Logs using environment variable `OTEL_PYTHON_REQUESTS_EXCLUDED_URLS`
